### PR TITLE
[sim] Updating WS port, number of simulated PWMs

### DIFF
--- a/src/components/sim/pwm/pwms.js
+++ b/src/components/sim/pwm/pwms.js
@@ -90,7 +90,7 @@ export default class Pwms extends Webbit {
       return html`<p>Start HALSim back-end to show PWMs.</p>`;
     }
 
-    const initializedPwms = getRange(8)
+    const initializedPwms = getRange(20)
       .map(index => {
         const initialized = source[index] && source[index].init;
         return {

--- a/src/source-providers/halsim/index.js
+++ b/src/source-providers/halsim/index.js
@@ -55,9 +55,9 @@ export default class HalSimProvider extends SourceProvider {
 
   setAddress(address) {
     if (address === 'gitpod') {
-      connect(`wss://8080${window.location.href.substring(12)}wpilibws`);
+      connect(`wss://3300${window.location.href.substring(12)}wpilibws`);
     } else {
-      connect(`ws://${address}:8080/wpilibws`);
+      connect(`ws://${address}:3300/wpilibws`);
     }
   }
 


### PR DESCRIPTION
The default WS port changed in WPI a couple weeks ago.

The number of PWM port has been updated based on the number of devices the HAL actually supports